### PR TITLE
fix: 영수증 뽑기 버튼 글자 색상, 배경 높이 수정

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,13 +1,20 @@
+import styled from 'styled-components';
 import Router from './router/Router';
 import GlobalStyle from './style/GlobalStyle';
 
 function App() {
   return (
-    <div className='App'>
+    <Root className='App'>
       <GlobalStyle />
       <Router />
-    </div>
+    </Root>
   );
 }
+
+const Root = styled.div`
+  max-width: 390px;
+  min-height: 100vh;
+  margin: 0 auto;
+`;
 
 export default App;

--- a/src/components/myPage/DailyFailureList.jsx
+++ b/src/components/myPage/DailyFailureList.jsx
@@ -47,10 +47,6 @@ export default function DailyFailureList({ nickname }) {
 const ListContainer = styled.div`
   width: 100%;
   height: calc(100vh - 320px);
-  overflow-y: scroll;
-  ::-webkit-scrollbar {
-    display: none;
-  }
 `;
 
 const List = styled.div`

--- a/src/pages/LoginPage/LoginPage.jsx
+++ b/src/pages/LoginPage/LoginPage.jsx
@@ -69,7 +69,7 @@ const LoginContainer = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
-  width: 390px;
+  width: 100%;
   height: 100vh;
   padding: 0 15px;
   margin: 0 auto;

--- a/src/pages/MyPage/MyPage.jsx
+++ b/src/pages/MyPage/MyPage.jsx
@@ -37,15 +37,22 @@ export default function MyPage() {
 const Container = styled.div`
   display: flex;
   flex-direction: column;
+  justify-content: center;
   align-items: center;
-  width: 390px;
+  width: 100%;
   height: 100vh;
   margin: 0 auto;
   background-color: white;
+  overflow: scroll;
+
+  ::-webkit-scrollbar {
+    display: none;
+  }
 `;
 
 const LogoContainer = styled.div`
   margin: 26px 0 16px 0;
+  height: 100%;
 `;
 
 const Main = styled.div`

--- a/src/pages/ReceiptPage/ReceiptPage.jsx
+++ b/src/pages/ReceiptPage/ReceiptPage.jsx
@@ -2,9 +2,9 @@ import axios from 'axios';
 import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import receiptBg from '../../assets/receipt.png';
-import FailCard from '../../components/receipt/FailCard';
-import CopyModal from '../../components/receipt/CopyModal';
 import Logo from '../../components/common/Logo';
+import CopyModal from '../../components/receipt/CopyModal';
+import FailCard from '../../components/receipt/FailCard';
 
 export default function UserSharePage() {
   const [data, setData] = useState([]);
@@ -100,8 +100,9 @@ export default function UserSharePage() {
 
 const Container = styled.section`
   background-color: #ffffff;
-  width: 390px;
-  height: 100vh;
+  width: 100%;
+  height: 100%;
+  min-height: 100vh;
   margin: 0 auto;
   padding: 26px 17px;
   display: flex;

--- a/src/pages/SharePage/SharePage.jsx
+++ b/src/pages/SharePage/SharePage.jsx
@@ -4,8 +4,8 @@ import { useParams } from 'react-router-dom';
 import styled from 'styled-components';
 import codeImg from '../../assets/barcode.svg';
 import receiptBg from '../../assets/share-bg.png';
-import FailCard from '../../components/receipt/FailCard';
 import Logo from '../../components/common/Logo';
+import FailCard from '../../components/receipt/FailCard';
 
 export default function SharePage() {
   const [date, setDate] = useState('');
@@ -67,7 +67,7 @@ export default function SharePage() {
 
 const Container = styled.section`
   background-color: #ffffff;
-  width: 390px;
+  width: 100%;
   height: 100vh;
   margin: 0 auto;
   padding: 26px 17px;

--- a/src/style/GlobalStyle.jsx
+++ b/src/style/GlobalStyle.jsx
@@ -20,7 +20,7 @@ const GlobalStyle = createGlobalStyle`
     margin:0;
     padding:0;
     background-image: url(${bg});
-
+    
     height: 100vh;
   }
 

--- a/src/style/GlobalStyle.jsx
+++ b/src/style/GlobalStyle.jsx
@@ -20,6 +20,8 @@ const GlobalStyle = createGlobalStyle`
     margin:0;
     padding:0;
     background-image: url(${bg});
+
+    height: 100vh;
   }
 
   a {
@@ -31,6 +33,7 @@ const GlobalStyle = createGlobalStyle`
     background: inherit;
     outline: none;
     padding: 0;
+    color: black;
   }
 
   h1,h2,h3, p, span{


### PR DESCRIPTION
<!--🚨 PR 날리기 전에 develop 브랜치에 merge하는지 확인해주세요!-->
<!-- 제목 양식 // 커밋타입: 작성한 이슈와 동일한 제목 -->
<!-- ex) feat: 로그인 기능 구현 -->
<!--제목의 형식이 알맞은지 확인해주세요!-->

## ⭐ 개요

영수증 뽑기 버튼 글자 색상, 배경 높이 수정

## 📋 작업사항

- [x] 영수증 뽑기 버튼 글자 색상 수정
- [x] 배경 높이 수정

## 😉 참고사항

<!--팀원들이 참고해야할 사항이 있으면 작성해주세요-->

아이폰 12 미니를 화면에서는 넓이가 390px보다 작아서 양옆으로 스크롤이 생기더라고요. 그래서 max-width를 390px로 하고 그거보다 작은 width도 가능하게 수정해봤습니다.

## 💻 스크린샷

<!-- 이미지나 작업내용을 공유해주세요 -->

![스크린샷 2023-03-06 오전 3 32 34](https://user-images.githubusercontent.com/45119238/222979040-4359b1b4-1201-40c9-a3bc-e0e03644462b.png)

![IMG_B835AC934B20-1 2](https://user-images.githubusercontent.com/45119238/222979363-a7d55f8b-c252-4e60-b8ee-1b3db2d86590.jpeg)

Closes #26
