### PR TITLE
design: 회원가입 페이지 UI 구현

### DIFF
--- a/src/components/signUp/SignUpForm.jsx
+++ b/src/components/signUp/SignUpForm.jsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import styled from 'styled-components';
+
+export default function SignUpForm({ title, id, maxLength, placeholder, type, warningText }) {
+  return (
+    <Container>
+      <Title htmlFor={id}>{title}</Title>
+      <InputContainer>
+        <Input id={id} placeholder={placeholder} type={type} />
+        <TextCounter>0 / {maxLength}</TextCounter>
+      </InputContainer>
+      <WarningText>{warningText}</WarningText>
+    </Container>
+  );
+}
+
+const Container = styled.section`
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 22px;
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+`;
+
+const Title = styled.label`
+  font-family: 'Pretendard';
+  font-style: normal;
+  font-weight: 600;
+  font-size: 16px;
+  line-height: 150%;
+  letter-spacing: -0.011em;
+  color: #1e1e1e;
+`;
+
+const InputContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  width: 100%;
+  margin-top: 16px;
+  /* 입력 상태(focus)일 때 컬러 변경(#848484) */
+  border: 1px solid #c7c7c7;
+  border-radius: 4px;
+`;
+
+const Input = styled.input`
+  flex-grow: 1;
+  height: 40px;
+  padding: 8px 10px;
+  background-color: rgba(0, 0, 0, 0);
+  border: none;
+
+  font-family: 'Pretendard';
+  font-style: normal;
+  font-weight: 500;
+  font-size: 16px;
+  line-height: 150%;
+  letter-spacing: -0.011em;
+  color: #848484;
+
+  &::placeholder {
+    font-family: 'Pretendard';
+    font-style: normal;
+    font-weight: 500;
+    font-size: 16px;
+    line-height: 150%;
+    letter-spacing: -0.011em;
+    color: #c7c7c7;
+  }
+
+  &:focus {
+    outline: none;
+  }
+`;
+
+// 타이핑 완료 시 display: none
+const TextCounter = styled.p`
+  padding: 8px 10px;
+  font-family: 'Pretendard';
+  font-style: normal;
+  font-weight: 500;
+  font-size: 16px;
+  line-height: 150%;
+  letter-spacing: -0.011em;
+  color: #c7c7c7;
+`;
+
+// validation 상태에 따라 컬러 변경(#2BCF4F)
+const WarningText = styled.strong`
+  margin: 5px 9px 0;
+  font-family: 'Pretendard';
+  font-style: normal;
+  font-weight: 400;
+  font-size: 12px;
+  line-height: 150%;
+  letter-spacing: -0.011em;
+  color: #ff4141;
+`;

--- a/src/pages/SharePage/SharePage.jsx
+++ b/src/pages/SharePage/SharePage.jsx
@@ -21,7 +21,7 @@ export default function SharePage() {
     fontSize: '16',
   };
 
-  const handleClick = () => {
+  const handleCopy = () => {
     navigator.clipboard.writeText(window.location.href).then(setIsVisibleModal(true));
   };
 
@@ -29,7 +29,7 @@ export default function SharePage() {
     <Container>
       <h1 className='sr-only'>나의 영수증 공유 페이지</h1>
       <ReceiptShareContainer />
-      <Button type={shareBtnType} text={'자랑하기'} handleClick={handleClick} />
+      <Button type={shareBtnType} text={'자랑하기'} handleClick={handleCopy} />
       {isVisibleModal && (
         <Modal mainText={'주소가 복사되었습니다'} subText={'오늘의 실패를  부담없이 공유해보세요!'}>
           <Button

--- a/src/pages/SignUpPage/SignUpPage.jsx
+++ b/src/pages/SignUpPage/SignUpPage.jsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function SignUpPage() {
+  return <div>SignUpPage</div>;
+}

--- a/src/pages/SignUpPage/SignUpPage.jsx
+++ b/src/pages/SignUpPage/SignUpPage.jsx
@@ -1,5 +1,83 @@
-import React from 'react';
+import styled from 'styled-components';
+import Button from '../../components/common/Button';
+import Logo from '../../components/common/Logo';
+import SignUpForm from '../../components/signUp/SignUpForm';
 
 export default function SignUpPage() {
-  return <div>SignUpPage</div>;
+  const buttonType = {
+    bgColor: 'black',
+    width: '359',
+    fontSize: '16',
+    isFixed: false,
+  };
+
+  return (
+    <LoginContainer>
+      <Logo />
+      <Title>회원가입</Title>
+      <FormContainer>
+        <SignUpForm
+          title={'닉네임'}
+          id={'nickname'}
+          maxLength={'10'}
+          placeholder={'닉네임을 정해주세요!'}
+          type={'text'}
+          warningText={'이미 존재하는 닉네임입니다'}
+        />
+        <SignUpForm
+          title={'비밀번호'}
+          id={'pw'}
+          maxLength={'16'}
+          placeholder={'비밀번호를 입력하세요'}
+          type={'password'}
+          warningText={'영문과 숫자를 조합하여 8자리 이상 입력해야 합니다'}
+        />
+        <SignUpForm
+          title={'비밀번호 확인'}
+          id={'pwCheck'}
+          maxLength={'16'}
+          placeholder={'비밀번호를 한번 더 입력하세요'}
+          type={'password'}
+          warningText={'비밀번호가 일치하지 않습니다'}
+        />
+      </FormContainer>
+      {/* 공통 컴포넌트 수정 후 버튼 수정 */}
+      <ButtonContainer>
+        <Button type={buttonType} text={'가입하기'} />
+      </ButtonContainer>
+    </LoginContainer>
+  );
 }
+
+const LoginContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  background-color: #ffffff;
+  max-width: 390px;
+  min-height: 100vh;
+  margin: 0 auto;
+  padding: 110px 15px 0;
+`;
+
+const Title = styled.h1`
+  margin-top: 6px;
+  font-family: 'Pretendard';
+  font-style: normal;
+  font-weight: 500;
+  font-size: 20px;
+  line-height: 150%;
+  text-align: center;
+  letter-spacing: -0.011em;
+  color: #1e1e1e;
+`;
+
+const FormContainer = styled.form`
+  margin-top: 48px;
+  width: 100%;
+  height: 100%;
+`;
+
+const ButtonContainer = styled.div`
+  margin-top: 79px;
+`;

--- a/src/router/Router.jsx
+++ b/src/router/Router.jsx
@@ -5,12 +5,14 @@ import LoginPage from '../pages/LoginPage/LoginPage';
 import MyPage from '../pages/MyPage/MyPage';
 import RecordPage from '../pages/RecordPage/RecordPage';
 import SharePage from '../pages/SharePage/SharePage';
+import SignUpPage from '../pages/SignUpPage/SignUpPage';
 
 export default function Router() {
   return (
     <BrowserRouter>
       <Routes>
         <Route path='/login' element={<LoginPage />} />
+        <Route path='/signup' element={<SignUpPage />} />
         <Route path='/' element={<MainLayout />}>
           <Route index element={<MyPage />} />
           <Route path='/recordPage' element={<RecordPage />} />


### PR DESCRIPTION
<!--🚨 PR 날리기 전에 develop 브랜치에 merge하는지 확인해주세요!-->
<!-- 제목 양식 // 커밋타입: 작성한 이슈와 동일한 제목 -->
<!-- ex) feat: 로그인 기능 구현 -->
<!--제목의 형식이 알맞은지 확인해주세요!-->

## ⭐ 개요

회원가입 페이지 UI를 구현합니다

## 📋 작업사항

- [x] 회원가입 페이지 추가 및 라우터에 추가
- [x] 회원가입 페이지 UI 구현

+) 추가 진행 사항
- [x] 공유페이지 handleClick 함수 함수명 변경

## 😉 참고사항

<!--팀원들이 참고해야할 사항이 있으면 작성해주세요-->

- 회원가입 페이지와 로그인 페이지의 버튼 스타일링이 바뀌어 공통 컴포넌트의 수정이 필요해 보입니다
-> 기존 컴포넌트를 사용하여 모든 정보가 입력되었을 시의 검은색 버튼으로 스타일링 해 두었기 때문에 공통 컴포넌트 수정 후 디자인 변경하도록 하겠습니다

- 상태에 따라 변경되어야 되는 값들은 주석으로 메모해 두었습니다
-> 기능 구현을 하며 상태에 맞게 디자인을 구현하도록 하겠습니다
-> `warningText`가 현재는 props 값으로 빨간색 텍스트만 전달하고 있는데 validation에 따라 변하는 값으로 추후 수정 예정입니다

## 💻 스크린샷

<!-- 이미지나 작업내용을 공유해주세요 -->
<img width="388" alt="스크린샷 2023-03-20 오후 8 52 43" src="https://user-images.githubusercontent.com/96907832/226331554-bf7ce4ae-0046-48bb-b76c-e747eaa41747.png">


Closes #53 
