### PR TITLE
fix: 회원가입 페이지 비밀번호 확인 및 엔터 submit 수정

### DIFF
--- a/src/api/apiController.jsx
+++ b/src/api/apiController.jsx
@@ -4,7 +4,9 @@ export const BASE_URL = process.env.REACT_APP_BASE_URL;
 
 // 사용자 정의 구성을 사용하는 axios 인스턴스 생성
 export default axios.create({
-  baseURL: BASE_URL,
+  // baseURL: BASE_URL,
+  baseURL: '',
+
   headers: {
     'Content-Type': 'application/json',
     // Authorization: `Bearer`, 토큰

--- a/src/api/apiController.jsx
+++ b/src/api/apiController.jsx
@@ -4,9 +4,7 @@ export const BASE_URL = process.env.REACT_APP_BASE_URL;
 
 // 사용자 정의 구성을 사용하는 axios 인스턴스 생성
 export default axios.create({
-  // baseURL: BASE_URL,
-  baseURL: '',
-
+  baseURL: BASE_URL,
   headers: {
     'Content-Type': 'application/json',
     // Authorization: `Bearer`, 토큰

--- a/src/pages/SignUpPage/SignUpPage.jsx
+++ b/src/pages/SignUpPage/SignUpPage.jsx
@@ -92,7 +92,9 @@ export default function SignUpPage() {
   };
 
   const pwCheckValid = () => {
-    if (pwCheck.length > 0) {
+    const regex = /^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d\w\W]{8,}$/;
+
+    if (pwCheck.length > 0 && regex.test(pwCheck)) {
       if (pwCheck === password) {
         return [setPwCheckWarnText('비밀번호가 일치합니다'), setIsPwCheckValid(true)];
       } else {
@@ -128,7 +130,7 @@ export default function SignUpPage() {
     }
   };
 
-  const handleClick = async () => {
+  const handleClick = async (e) => {
     if (!isDisabled) {
       await axios
         .post(`/member`, {
@@ -139,6 +141,8 @@ export default function SignUpPage() {
           navigate('/login');
         })
         .catch((res) => {});
+    } else {
+      return e.preventDefault();
     }
   };
 
@@ -159,10 +163,10 @@ export default function SignUpPage() {
         <SignUpForm {...nicknameProps} />
         <SignUpForm {...passwordProps} />
         <SignUpForm {...passwordCheckProps} />
+        <ButtonContainer>
+          <SignUpButton text={'가입하기'} handleClick={handleClick} isDisabled={isDisabled} />
+        </ButtonContainer>
       </FormContainer>
-      <ButtonContainer>
-        <SignUpButton text={'가입하기'} handleClick={handleClick} isDisabled={isDisabled} />
-      </ButtonContainer>
     </LoginContainer>
   );
 }

--- a/src/pages/SignUpPage/SignUpPage.jsx
+++ b/src/pages/SignUpPage/SignUpPage.jsx
@@ -137,12 +137,18 @@ export default function SignUpPage() {
           name: nickname,
           password,
         })
-        .then((res) => {
+        .then(() => {
           navigate('/login');
         })
         .catch((res) => {});
     } else {
       return e.preventDefault();
+    }
+  };
+
+  const handleEnter = (e) => {
+    if (e.keyCode === 13) {
+      handleClick();
     }
   };
 
@@ -159,14 +165,14 @@ export default function SignUpPage() {
     <LoginContainer>
       <Logo />
       <Title>회원가입</Title>
-      <FormContainer>
+      <FormContainer onKeyUp={handleEnter}>
         <SignUpForm {...nicknameProps} />
         <SignUpForm {...passwordProps} />
         <SignUpForm {...passwordCheckProps} />
-        <ButtonContainer>
-          <SignUpButton text={'가입하기'} handleClick={handleClick} isDisabled={isDisabled} />
-        </ButtonContainer>
       </FormContainer>
+      <ButtonContainer>
+        <SignUpButton text={'가입하기'} handleClick={handleClick} isDisabled={isDisabled} />
+      </ButtonContainer>
     </LoginContainer>
   );
 }

--- a/src/pages/SignUpPage/SignUpPage.jsx
+++ b/src/pages/SignUpPage/SignUpPage.jsx
@@ -93,7 +93,7 @@ export default function SignUpPage() {
 
   const pwCheckValid = () => {
     if (pwCheck.length > 0) {
-      if (password === pwCheck) {
+      if (pwCheck === password) {
         return [setPwCheckWarnText('비밀번호가 일치합니다'), setIsPwCheckValid(true)];
       } else {
         return [setPwCheckWarnText('비밀번호가 일치하지 않습니다'), setIsPwCheckValid(false)];
@@ -117,11 +117,8 @@ export default function SignUpPage() {
 
   useUpdateEffect(() => {
     passwordValid();
-  }, [password]);
-
-  useUpdateEffect(() => {
     pwCheckValid();
-  }, [pwCheck]);
+  }, [password, pwCheck]);
 
   const activeButton = () => {
     if (isNicknameValid && isNicknameValid && isPwCheckValid) {


### PR DESCRIPTION
<!--🚨 PR 날리기 전에 develop 브랜치에 merge하는지 확인해주세요!-->
<!-- 제목 양식 // 커밋타입: 작성한 이슈와 동일한 제목 -->
<!-- ex) feat: 로그인 기능 구현 -->
<!--제목의 형식이 알맞은지 확인해주세요!-->

## ⭐ 개요

작업내역명(페이지명)

## 📋 작업사항

- [x] 비밀번호 확인 먼저 입력 후 비밀번호 입력하면 일치해도 일치하지 않는다고 뜨는 현상 해결
- [x] 모든 정보 입력 시 엔터 치면 submit 되도록 수정
- [x] 비밀번호 확인 유효성 검사 추가

## 😉 참고사항

<!--팀원들이 참고해야할 사항이 있으면 작성해주세요-->
비밀번호 확인 시 비밀번호가 유효성 검사가 통과되지 않았는데도 비밀번호가 일치하다면 버튼이 활성화되는 이슈가 있어서 유효성 검사를 추가하였습니다

## 💻 스크린샷

<!-- 이미지나 작업내용을 공유해주세요 -->

Closes #86 
